### PR TITLE
Use RegEx to detect poetry's dependencies sections to support custom groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ An extension for managing Python dependencies. At the moment it only supports py
 
 ![2021-02-28 16 40 01](https://user-images.githubusercontent.com/667029/109424385-b2d87780-79e3-11eb-85e9-6931063f4210.gif)
 
+
+## ❤️ Contributing
+
+- Fork and clone repository:
+
+    ```shell
+    git@github.com:<your-fork>/python-dependencies-vscode.git
+    cd python-dependencies-vscode
+    ```
+- Install dependencies
+  ```shell
+
+  npm install
+  ```
+- Run extension using VS Code's "Run and Debug" menu, select `Run Extension` option
+
+
 ## Roadmap
 
 -   [ ] Add support for updating dependencies

--- a/src/utils/parsing/toml.ts
+++ b/src/utils/parsing/toml.ts
@@ -51,11 +51,9 @@ export const findDependencies = (text: string) => {
         if (line.startsWith("[")) {
             lastSection = line.replace(/^\[/, "").replace(/\]$/, "");
         } else {
+            const poetryDependenciesRe = new RegExp("^tool\.poetry\..*dependencies$")
             if (
-                [
-                    "tool.poetry.dependencies",
-                    "tool.poetry.dev-dependencies",
-                ].includes(lastSection)
+                poetryDependenciesRe.test(lastSection)
             ) {
                 const dep = parseDependency(line, index);
 


### PR DESCRIPTION
Poetry 1.2 has introduced custom groups for dependencies sections, I updated the if about sections to use a RegEx. 
I tested locally and seems working :) 

Wasn't able to run `Extension Tests`, but I think something on my VS Code is not configured correctly... 
